### PR TITLE
Update require directive to plugins directive for new rubocop syntax

### DIFF
--- a/ruby/rubocop-cache-ventures.gemspec
+++ b/ruby/rubocop-cache-ventures.gemspec
@@ -7,10 +7,10 @@ Gem::Specification.new do |s|
 
   s.license = 'MIT'
 
-  s.version = '1.2.0'
+  s.version = '2.0.0'
   s.platform = Gem::Platform::RUBY
 
-  s.add_dependency 'rubocop'
+  s.add_dependency 'rubocop', '>= 1.72.0'
   s.add_dependency 'rubocop-rails'
   s.add_dependency 'rubocop-performance'
   s.add_dependency 'rubocop-minitest'

--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-minitest
   - rubocop-performance
   - rubocop-rails


### PR DESCRIPTION
See https://docs.rubocop.org/rubocop/plugin_migration_guide.html for details.