### PR TITLE
Enable and configure Layout rules, and add README note

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,13 @@ team at Cache Ventures.
 
 After the Ruby gem is updated in a project, in order to get rubocop to read the
 new rubocop.yml, you may need to run `rubocop --restart-server`.
+
+## Ruby `.rubocop` file
+
+We have Layout/LineLength enabled with autocorrection off and a line length of 80 configured. In order to enable linting in our editors without having rubocop output all of the violations for the line length being exceeded when it runs, each project including the Ruby gem should have a .rubocop file in its base directory, containing the following line:
+
+```
+--display-only-fail-level-offenses
+```
+
+This configures a default argument for rubocop. If you want to override it to display the line length violations, you can pass `RUBOCOP_OPTS=` before the rubocop command on the CLI, since the environment variable options take precedence over the .rubocop file's arguments.

--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -28,8 +28,35 @@ Bundler:
 Bundler/OrderedGems:
   Enabled: false
 
-Layout/EmptyLineAfterGuardClause:
+Layout:
   Enabled: true
+
+Layout/DotPosition:
+  EnforcedStyle: trailing
+
+# will be enabled by default in the future
+Layout/EmptyLinesAfterModuleInclusion:
+  Enabled: true
+
+Layout/LineContinuationLeadingSpace:
+  Enabled: true
+
+Layout/LineContinuationSpacing:
+  Enabled: true
+
+Layout/LineEndStringConcatenationIndentation:
+  Enabled: true
+
+Layout/LineLength:
+  Severity: info
+  Max: 80
+  AutoCorrect: disabled
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
+Layout/MultilineOperationIndentation:
+  EnforcedStyle: indented
 
 Lint:
   Enabled: true


### PR DESCRIPTION
Enable and configure Layout rules, and add README note about .rubocop file and the default argument for Layout/LineLength