### PR TITLE
Ruby gem 3.0.0 release

### DIFF
--- a/ruby/rubocop-cache-ventures.gemspec
+++ b/ruby/rubocop-cache-ventures.gemspec
@@ -7,10 +7,10 @@ Gem::Specification.new do |s|
 
   s.license = 'MIT'
 
-  s.version = '2.0.0'
+  s.version = '3.0.0'
   s.platform = Gem::Platform::RUBY
 
-  s.add_dependency 'rubocop', '>= 1.72.0'
+  s.add_dependency 'rubocop', '>= 1.79.0'
   s.add_dependency 'rubocop-rails'
   s.add_dependency 'rubocop-performance'
   s.add_dependency 'rubocop-minitest'


### PR DESCRIPTION
Ruby gem 3.0.0 release, increase minimum rubocop version